### PR TITLE
Fix thread ID consistency

### DIFF
--- a/hooks/useChat.ts
+++ b/hooks/useChat.ts
@@ -12,44 +12,44 @@ interface User {
 }
 
 interface ThreadData {
-    id: number;
+    id: string;
     messages: Message[];
     input: string;
     user?: User;
 }
 
 interface ChatStore {
-    currentThreadId: number | undefined;
+    currentThreadId: string | undefined;
     user: User | undefined;
-    threads: Record<number, ThreadData>;
-    setCurrentThreadId: (id: number) => void;
+    threads: Record<string, ThreadData>;
+    setCurrentThreadId: (id: string) => void;
     setUser: (user: User) => void;
-    getThreadData: (id: number) => ThreadData;
-    setMessages: (id: number, messages: Message[]) => void;
-    setInput: (id: number, input: string) => void;
+    getThreadData: (id: string) => ThreadData;
+    setMessages: (id: string, messages: Message[]) => void;
+    setInput: (id: string, input: string) => void;
 }
 
 const useChatStore = create<ChatStore>((set, get) => ({
     currentThreadId: undefined,
     user: undefined,
     threads: {},
-    setCurrentThreadId: (id: number) => set({ currentThreadId: id }),
+    setCurrentThreadId: (id: string) => set({ currentThreadId: id }),
     setUser: (user: User) => set({ user }),
-    getThreadData: (id: number) => {
+    getThreadData: (id: string) => {
         const { threads } = get();
         if (!threads[id]) {
             threads[id] = { id, messages: [], input: '' };
         }
         return threads[id];
     },
-    setMessages: (id: number, messages: Message[]) =>
+    setMessages: (id: string, messages: Message[]) =>
         set(state => ({
             threads: {
                 ...state.threads,
                 [id]: { ...state.threads[id], messages }
             }
         })),
-    setInput: (id: number, input: string) =>
+    setInput: (id: string, input: string) =>
         set(state => ({
             threads: {
                 ...state.threads,
@@ -59,7 +59,7 @@ const useChatStore = create<ChatStore>((set, get) => ({
 }));
 
 interface UseChatProps {
-    id?: number;
+    id?: string;
 }
 
 export function useChat({ id: propsId }: UseChatProps = {}) {
@@ -77,7 +77,7 @@ export function useChat({ id: propsId }: UseChatProps = {}) {
         setInput: setStoreInput
     } = useChatStore();
 
-    const [threadId, setThreadId] = useState<number | null>(propsId || currentThreadId || null);
+    const [threadId, setThreadId] = useState<string | null>(propsId || currentThreadId || null);
 
     const { threadId: createdThreadId, createNewThread } = useThreadCreation(threadId);
 
@@ -107,7 +107,7 @@ export function useChat({ id: propsId }: UseChatProps = {}) {
     }
 
     const vercelChatProps = useVercelChat({
-        id: threadId?.toString(),
+        id: threadId,
         initialMessages: threadData.messages,
         body,
         maxToolRoundtrips: 20,


### PR DESCRIPTION
This PR addresses the issue where thread IDs were not being properly passed to the useChat hook and API routes. The main changes include:

1. Updated hooks/useChat.ts to use string IDs instead of numbers for thread IDs.
2. Confirmed that components/chat.tsx, store/hud.ts, and hooks/useThreadCreation.ts were already using string IDs correctly.

These changes ensure that thread IDs are consistently passed as strings throughout the application, from the creation of new chat panes to the use of the useChat hook and the API routes.

Note: API routes and server-side code that handle thread IDs should be updated to expect string IDs instead of numbers if they haven't been already.