### PR TITLE
Fix dynamic tool list generation in system prompt

### DIFF
--- a/lib/systemPrompt.ts
+++ b/lib/systemPrompt.ts
@@ -14,10 +14,19 @@ HUMOR LEVEL: 5%
 You are the AutoDev terminal at OpenAgents.com. Respond extremely concisely in a neutral, terminal-like manner. Do not break character.
 
 Available tools:
-${selectedTools.map(tool => `- \`${tool}\` - ${allTools[tool].description}`).join('\n')}
+${Array.isArray(selectedTools) && selectedTools.length > 0
+  ? selectedTools.map(tool => `- \`${tool}\` - ${allTools[tool]?.description || 'No description available'}`).join('\n')
+  : 'No tools currently available.'
+}
 
 Deactivated tools:
-${Object.keys(allTools).filter(tool => !selectedTools.includes(tool)).map(tool => `- \`${tool}\` - ${allTools[tool].description}`).join('\n')}
+${Array.isArray(selectedTools)
+  ? Object.keys(allTools)
+      .filter(tool => !selectedTools.includes(tool))
+      .map(tool => `- \`${tool}\` - ${allTools[tool]?.description || 'No description available'}`)
+      .join('\n')
+  : 'Unable to determine deactivated tools.'
+}
 
 Primary functions:
 1. Analyze project structure and codebase


### PR DESCRIPTION
This pull request addresses the issue with dynamically generating the tool list in the system prompt. The main changes are:

1. Added checks to ensure `selectedTools` is an array and has elements before using the `map` function.
2. Added a fallback message when there are no available tools.
3. Added error handling for the deactivated tools section.
4. Used optional chaining (`?.`) when accessing `allTools[tool].description` to prevent errors if a tool is not found in the `allTools` object.

These changes should resolve the "Cannot read properties of undefined (reading 'map')" error that was occurring when sending a message.

Changes made in `lib/systemPrompt.ts`:
- Updated the `basePrompt` function to handle cases where `selectedTools` might be empty or undefined.
- Added error handling and fallback messages for both available and deactivated tools sections.

This should fix the issue and allow the system prompt to be generated correctly, even when no tools are selected or when there are missing tool descriptions.