### PR TITLE
Fix ToolResult display for complex values

### DIFF
--- a/panes/chat/ToolResult.tsx
+++ b/panes/chat/ToolResult.tsx
@@ -44,7 +44,21 @@ const getToolParams = (toolName: string, args: any): string => {
     }
   }
   const filteredArgs = Object.entries(args).filter(([key]) => !['token', 'repoContext', 'content', 'path'].includes(key));
-  return filteredArgs.map(([key, value]) => `${key}: ${typeof value === 'string' ? value : '[complex value]'}`).join(', ');
+  return filteredArgs.map(([key, value]) => {
+    if (typeof value === 'string') {
+      return `${key}: ${value}`;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      return `${key}: ${value}`;
+    } else if (value === null) {
+      return `${key}: null`;
+    } else if (Array.isArray(value)) {
+      return `${key}: [Array]`;
+    } else if (typeof value === 'object') {
+      return `${key}: {Object}`;
+    } else {
+      return `${key}: ${typeof value}`;
+    }
+  }).join(', ');
 };
 
 export const ToolResult: React.FC<ToolResultProps> = ({ toolName, args, result, state }) => {


### PR DESCRIPTION
This PR addresses issue #72 by improving the `getToolParams` function in `panes/chat/ToolResult.tsx`. The function now handles different types of values more specifically, providing a clearer representation of complex values instead of showing '[complex value]' for all non-string types.

Changes made:
- Updated `getToolParams` function to handle different value types (string, number, boolean, null, array, object)
- Improved readability of tool parameters in the UI

This change should resolve the issue of showing malformed data in the ToolResult component.