### PR TITLE
Fix ToolResult display for complex values

### DIFF
--- a/panes/chat/ToolResult.tsx
+++ b/panes/chat/ToolResult.tsx
@@ -44,7 +44,21 @@ const getToolParams = (toolName: string, args: any): string => {
     }
   }
   const filteredArgs = Object.entries(args).filter(([key]) => !['token', 'repoContext', 'content', 'path'].includes(key));
-  return filteredArgs.map(([key, value]) => `${key}: ${typeof value === 'string' ? value : '[complex value]'}`).join(', ');
+  return filteredArgs.map(([key, value]) => {
+    if (typeof value === 'string') {
+      return `${key}: ${value}`;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      return `${key}: ${value}`;
+    } else if (value === null) {
+      return `${key}: null`;
+    } else if (Array.isArray(value)) {
+      return `${key}: [Array]`;
+    } else if (typeof value === 'object') {
+      return `${key}: {Object}`;
+    } else {
+      return `${key}: ${typeof value}`;
+    }
+  }).join(', ');
 };
 
 export const ToolResult: React.FC<ToolResultProps> = ({ toolName, args, result, state }) => {


### PR DESCRIPTION
This pull request addresses issue #74 by improving the display of complex values in the ToolResult component.

Changes made:
1. Modified the `getToolParams` function in `panes/chat/ToolResult.tsx` to handle different types of values more specifically.
2. Instead of showing "[complex value]" for non-string values, it now displays:
   - The actual value for strings, numbers, and booleans
   - "null" for null values
   - "[Array]" for arrays
   - "{Object}" for objects
   - The type of the value for any other cases

This change resolves the issue of showing malformed data in the ToolResult component, providing a clearer and more informative display of tool parameters.