### PR TITLE
Fix ToolResult display for complex values

### DIFF
--- a/panes/chat/ToolResult.tsx
+++ b/panes/chat/ToolResult.tsx
@@ -44,7 +44,21 @@ const getToolParams = (toolName: string, args: any): string => {
     }
   }
   const filteredArgs = Object.entries(args).filter(([key]) => !['token', 'repoContext', 'content', 'path'].includes(key));
-  return filteredArgs.map(([key, value]) => `${key}: ${typeof value === 'string' ? value : '[complex value]'}`).join(', ');
+  return filteredArgs.map(([key, value]) => {
+    if (typeof value === 'string') {
+      return `${key}: ${value}`;
+    } else if (typeof value === 'number' || typeof value === 'boolean') {
+      return `${key}: ${value}`;
+    } else if (value === null) {
+      return `${key}: null`;
+    } else if (Array.isArray(value)) {
+      return `${key}: [Array]`;
+    } else if (typeof value === 'object') {
+      return `${key}: {Object}`;
+    } else {
+      return `${key}: ${typeof value}`;
+    }
+  }).join(', ');
 };
 
 export const ToolResult: React.FC<ToolResultProps> = ({ toolName, args, result, state }) => {


### PR DESCRIPTION
This PR addresses issue #78: ToolResult shows malformed data.

Changes made:
- Updated the `getToolParams` function in `panes/chat/ToolResult.tsx` to handle different types of values more appropriately.
- Instead of showing '[complex value]' for non-string values, it now displays:
  - Actual values for strings, numbers, and booleans
  - '[Array]' for arrays
  - '{Object}' for objects
  - 'null' for null values
  - The type of the value for any other cases

This change will provide more informative and accurate displays of tool parameters in the UI.